### PR TITLE
Add a fix for mismatch tags

### DIFF
--- a/IntersectionInfo.h
+++ b/IntersectionInfo.h
@@ -2,7 +2,7 @@
 #define IntersectionInfo_h_
 
 namespace pelfrey {
-class Object;
+struct Object;
 
 struct IntersectionInfo {
   float t; // Intersection distance along the ray


### PR DESCRIPTION
'Object' defined as a struct here but previously
      declared as a class; this is valid, but may result
      in linker errors under the Microsoft C++ ABI
      [-Werror,-Wmismatched-tags]